### PR TITLE
add event to greetings example and wait for new greeting to be mined

### DIFF
--- a/contracts/greeter.v.py
+++ b/contracts/greeter.v.py
@@ -1,18 +1,27 @@
 # Greeter.v.py
 # -----------( T. Leijtens, v1.0, Nov 2017 )
 
-greeting: public(bytes <= 20)
+Newgreeting: __log__({_sender: indexed(address), _newgreeting: bytes <= 20})
 
+greeting: public( bytes <= 20)
+
+@public
 def __init__(_greeting: bytes <= 20):
 	self.greeting = _greeting
 
-def setGreeting(_greeting: bytes <= 20):
+@public
+@payable
+def setGreeting(_greeting: bytes <= 20) -> bool:
 	self.greeting = _greeting
+	log.Newgreeting( msg.sender, _greeting)
+	return True
 
+@public
 @constant
 def greet() -> bytes <= 20:
 	return self.greeting
 
+@public
 @constant
 def sayHello() -> bytes <= 20:
 	return "Hello" 

--- a/example.js
+++ b/example.js
@@ -27,30 +27,34 @@ if (options['host']) {
 if (options['arguments']) {
 	PARAMETERS = options['arguments'];
 } else {
-	PARAMETERS = "Hello World"	
+	PARAMETERS = "Hello World"
 } 
 
 if (options['gas']) {
 	GAS = options['gas'];
 } else {
-	GAS = 300000	
+	GAS = 500000	
 } 
 
 const Web3 = require('web3');
 const web3 = new Web3(new Web3.providers.HttpProvider(RPC_ADDRESS));
 
-Deployer.deployContract(FILENAME, RPC_ADDRESS, GAS, 'Hello World', function(contractInstance) {
+Deployer.deployContract(FILENAME, RPC_ADDRESS, GAS, "Initial Greetings!", function(contractInstance) {
 
 	greeter = contractInstance;
 
 	greeting = greeter.greet.call();
-	console.log("[-->] Initial greeting:", web3.toAscii(greeting))
+	console.log("[-->] Initial greeting:", web3.toAscii(greeting));
 
-	console.log("[+] Setting new greeting...")
+	console.log("[+] Setting new greeting...");
+
 	greeter.setGreeting(PARAMETERS, {from: web3.eth.accounts[0], gas: GAS});
-	
-	greeting = greeter.greet.call()
-	console.log("[--> New Greeting:", web3.toAscii(greeting))
+
+	var myEvent = contract.Newgreeting({eventType: 1},{fromBlock: 0, toBlock: 'latest'});
+    myEvent.watch(function(error, result){
+
+		myEvent.stopWatching();
+		console.log("[--> New Greeting:", web3.toAscii(result.args._newgreeting));
+    });
 
 });
-

--- a/example.js
+++ b/example.js
@@ -53,8 +53,10 @@ Deployer.deployContract(FILENAME, RPC_ADDRESS, GAS, "Initial Greetings!", functi
 	var myEvent = contract.Newgreeting({eventType: 1},{fromBlock: 0, toBlock: 'latest'});
     myEvent.watch(function(error, result){
 
-		myEvent.stopWatching();
-		console.log("[--> New Greeting:", web3.toAscii(result.args._newgreeting));
+    	if ( !error) {
+			myEvent.stopWatching();
+			console.log("[--> New Greeting:", web3.toAscii(result.args._newgreeting));
+		}
     });
 
 });


### PR DESCRIPTION
With the latest Viper you must add decorations to all Viper functions. Removing @public will break the code.  Also setting a new greeting means that you will need to wait until that state was updated (mined).  This was not happening in the previous version.  Hence this update where I introduced events and a listener for that event to detect the update to the state. T.