### PR TITLE
Update to the Vyper deployer

### DIFF
--- a/contracts/greeter.v.py
+++ b/contracts/greeter.v.py
@@ -1,27 +1,27 @@
 # Greeter.v.py
 # -----------( T. Leijtens, v1.0, Nov 2017 )
 
-Newgreeting: event({_sender: indexed(address), _newgreeting: bytes[20]})
+Newgreeting: event({_sender: indexed(address), _newgreeting: string[20]})
 
-greeting: public( bytes[20])
+greeting: public( string[20])
 
 @public
-def __init__(_greeting: bytes[20]):
+def __init__(_greeting: string[20]):
 	self.greeting = _greeting
 
 @public
 @payable
-def setGreeting(_greeting: bytes[20]) -> bool:
+def setGreeting(_greeting: string[20]) -> bool:
 	self.greeting = _greeting
 	log.Newgreeting( msg.sender, _greeting)
 	return True
 
 @public
 @constant
-def greet() -> bytes[20]:
+def greet() -> string[20]:
 	return self.greeting
 
 @public
 @constant
-def sayHello() -> bytes[20]:
+def sayHello() -> string[20]:
 	return "Hello" 

--- a/example.js
+++ b/example.js
@@ -44,7 +44,7 @@ Deployer.deployContract(FILENAME, RPC_ADDRESS, GAS, "Initial Greetings!", functi
 	greeter = contractInstance;
 
 	greeting = greeter.greet.call();
-	console.log("[-->] Initial greeting:", web3.toAscii(greeting));
+	console.log("[-->] Initial greeting:", greeting);
 
 	console.log("[+] Setting new greeting...");
 
@@ -55,7 +55,7 @@ Deployer.deployContract(FILENAME, RPC_ADDRESS, GAS, "Initial Greetings!", functi
 
     	if ( !error) {
 			myEvent.stopWatching();
-			console.log("[-->] New Greeting:", web3.toAscii(result.args._newgreeting), " msg_sender:", result.args._sender);
+			console.log("[-->] New Greeting:", result.args._newgreeting, " msg_sender:", result.args._sender);
 		}
     });
 

--- a/example.js
+++ b/example.js
@@ -55,7 +55,7 @@ Deployer.deployContract(FILENAME, RPC_ADDRESS, GAS, "Initial Greetings!", functi
 
     	if ( !error) {
 			myEvent.stopWatching();
-			console.log("[-->] New Greeting:", web3.toAscii(result.args._newgreeting));
+			console.log("[-->] New Greeting:", web3.toAscii(result.args._newgreeting), " msg_sender:", result.args._sender);
 		}
     });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,20 +9,21 @@
       "resolved": "https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz",
       "integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
       "requires": {
-        "typical": "2.6.1"
+        "typical": "^2.6.1"
       }
     },
     "bignumber.js": {
-      "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
+      "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
+      "from": "bignumber.js@git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
     },
     "command-line-args": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-4.0.7.tgz",
       "integrity": "sha512-aUdPvQRAyBvQd2n7jXcsMDz68ckBJELXNzBybCHOibUWEg0mWTnaYCSRU8h9R+aNRSvDihJtssSRCiDRpLaezA==",
       "requires": {
-        "array-back": "2.0.0",
-        "find-replace": "1.0.3",
-        "typical": "2.6.1"
+        "array-back": "^2.0.0",
+        "find-replace": "^1.0.3",
+        "typical": "^2.6.1"
       }
     },
     "crypto-js": {
@@ -35,8 +36,8 @@
       "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-1.0.3.tgz",
       "integrity": "sha1-uI5zZNLZyVlVnziMZmcNYTBEH6A=",
       "requires": {
-        "array-back": "1.0.4",
-        "test-value": "2.1.0"
+        "array-back": "^1.0.4",
+        "test-value": "^2.1.0"
       },
       "dependencies": {
         "array-back": {
@@ -44,7 +45,7 @@
           "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
           "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
           "requires": {
-            "typical": "2.6.1"
+            "typical": "^2.6.0"
           }
         }
       }
@@ -54,8 +55,8 @@
       "resolved": "https://registry.npmjs.org/test-value/-/test-value-2.1.0.tgz",
       "integrity": "sha1-Edpv9nDzRxpztiXKTz/c97t0gpE=",
       "requires": {
-        "array-back": "1.0.4",
-        "typical": "2.6.1"
+        "array-back": "^1.0.3",
+        "typical": "^2.6.0"
       },
       "dependencies": {
         "array-back": {
@@ -63,7 +64,7 @@
           "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
           "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
           "requires": {
-            "typical": "2.6.1"
+            "typical": "^2.6.0"
           }
         }
       }
@@ -84,10 +85,10 @@
       "integrity": "sha1-qru+Nf5sq+gRZZCHpVzIbpkzbHQ=",
       "requires": {
         "bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-        "crypto-js": "3.1.8",
-        "utf8": "2.1.2",
-        "xhr2": "0.1.4",
-        "xmlhttprequest": "1.8.0"
+        "crypto-js": "^3.1.4",
+        "utf8": "^2.1.1",
+        "xhr2": "*",
+        "xmlhttprequest": "*"
       }
     },
     "xhr2": {


### PR DESCRIPTION
Observation: The example contract was no longer working.

Reason: Vyper issue #1210 was re-introducing the String type ("[String type #1210](https://github.com/ethereum/vyper/issues/1210) --> Add `string` type so that the context is clearer in web3, etc.")

Fix: Replace all bytes[ .. ] occurences with string[ .. ] and remove the conversion to bytes from the example.js script.

Tested I and all works. I hope you can accept this merge request.